### PR TITLE
feat: Implement dark mode

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -203,3 +203,43 @@
     lazyLoadImages();
 
 })(jQuery);
+
+// Dark Mode Toggle Functionality
+document.addEventListener('DOMContentLoaded', function () {
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+
+    // Function to apply theme and update button text
+    const applyTheme = (theme) => {
+        if (theme === 'dark') {
+            body.classList.add('dark-mode');
+            darkModeToggle.textContent = 'Mode Clair'; // Text for switching to light mode
+        } else {
+            body.classList.remove('dark-mode');
+            darkModeToggle.textContent = 'Mode Sombre'; // Text for switching to dark mode
+        }
+    };
+
+    // Check localStorage for saved theme preference
+    const currentTheme = localStorage.getItem('theme');
+    if (currentTheme) {
+        applyTheme(currentTheme);
+    } else {
+        // Default to light mode if no preference is saved
+        applyTheme('light');
+    }
+
+    // Add event listener to the toggle button
+    if (darkModeToggle) {
+        darkModeToggle.addEventListener('click', function () {
+            let newTheme;
+            if (body.classList.contains('dark-mode')) {
+                newTheme = 'light';
+            } else {
+                newTheme = 'dark';
+            }
+            localStorage.setItem('theme', newTheme);
+            applyTheme(newTheme);
+        });
+    }
+});

--- a/assets/sass/base/_dark-theme.scss
+++ b/assets/sass/base/_dark-theme.scss
@@ -1,0 +1,279 @@
+// Dark Theme Styles
+
+@import '../libs/vars';
+
+body.dark-mode {
+  background-color: map-get($dark-palette, bg);
+  color: map-get($dark-palette, fg);
+
+  h1, h2, h3, h4, h5, h6 {
+    color: map-get($dark-palette, fg-bold);
+  }
+
+  a {
+    color: map-get($dark-palette, accent);
+
+    &:hover {
+      color: map-get($dark-palette, accent-alt);
+    }
+  }
+
+  // Base border color
+  hr,
+  input,
+  select,
+  textarea {
+    border-color: map-get($dark-palette, border);
+  }
+
+  // More specific styles will be added below
+
+  // Wrapper background for dark mode (left side panel)
+  #wrapper {
+    &:before {
+      background-color: map-get($dark-palette, accent);
+      // Adjust SVG fill for dark mode if necessary, or use a different SVG
+      // For now, let's make the SVG pattern a bit more subtle or use a darker accent
+      background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 1750" x="0px" y="0px"> <path style="fill: #{transparentize(map-get($dark-palette, accent-border), 0.75)}" d="M889.72,1137.55l-2.91-0.75l-364.39,282.94l-0.7-0.9l-0.51,0.11l-94.77-451.5l-32.51-15.75l-16.73-8.11l0,0.68 l-1.46,0l0-1.39l-1.89-0.92l-112.41-54.47l-0.29,1.03l-1.41-0.37l0.37-1.31l-34.14-16.54l-98.56-47.76l-0.59,0.81l-1.16-0.88 l0.42-0.57L11.43,766.33l-0.25,0.2l-0.9-1.15l102.87-79.98l0.08-0.1l0.02,0.02l116.68-90.72l-0.18-0.34l1.3-0.66l0.05,0.09 l100.5-78.14l-0.07-0.32l0.65-0.14l42.3-32.89l-0.15-54.54l-0.59,0.29l-0.64-1.31l1.23-0.6l-0.01-4.54l-0.33-122.47l-0.99,0.18 l-0.28-1.43l1.27-0.23l-0.4-147.49l-0.87-0.16l0.28-1.43l0.58,0.1l-0.35-127.48l-0.13-0.06l0.64-1.31L489.97,76.8l0.73,0.19 l-0.04,0.14l132.63,65.11l0.33-0.45l1.16,0.88l-0.16,0.22l114.21,56.07l0.45-0.35l0.72,0.93l47.89,23.51l2.76-1.36l0.56,4.61 l-3.32-1.63L571.52,330.88L375.95,482.93l0.66,239.95l51.12,243.57l222.53,107.83l236.23,60.93l2.27-1.77 M375.8,425.34l17.25-8.47 l36.13-127.75l-53.73,9.66L375.8,425.34z M551,241.05l38.19-52.2l-123.83-22.27l-34.13,120.68l98.99-17.81L551,241.05z M532.3,269.09l151.34-27.22l37.63-29.25l-130.48-23.47L532.3,269.09z M303.38,733.9l-2.36-4.48l-44.18-83.78L182.5,747.25 l40.78,36.46l52.69,47.11L303.38,733.9z M277.18,831.91l56.95,50.93L375.69,920l-0.13-49.23l-71.19-135L277.18,831.91z M303.96,731.86l41.93-148.25l-9.74-46.39L257.8,644.33L303.96,731.86z M304.94,733.73l9.55,18.12l61.05,115.78l-0.39-144.6 l-16.9-80.53l-11.71-55.81L304.94,733.73z M375.21,211.79l0.23,85.51l54.17-9.74l34.29-121.23l-88.87-15.98L375.21,211.79z M430.78,288.83l-17.88,63.21L394.81,416l44.01-21.6l90.15-123.23L430.78,288.83z M287.76,898.62l87.99,42.64l-0.05-19.29 l-91.37-81.71l-7.59-6.78l-14.88,52.59L287.76,898.62z M174.26,843.62l86.26,41.8l15-53.03l-93.89-83.95l-53.34,72.91L174.26,843.62 z M113.18,687.22L12.71,765.33l55.69,26.99l58.56,28.38l53.58-73.24l-34.83-31.14L113.18,687.22z M230.62,595.92l-116.27,90.4 l63.02,56.36l4.03,3.61l74.67-102.08l-7.47-14.17L230.62,595.92z M331.94,517.15l-100.15,77.86l25.25,47.88l78.71-107.59l-1.71-8.14 L331.94,517.15z M333.22,516.15l2.02,9.64l1.66,7.92l34.65-47.37L333.22,516.15z M337.31,535.63l9.43,44.95l26.67-94.3 L337.31,535.63z M347.39,583.66l27.74,132.16l-0.62-228.04L347.39,583.66z M374.7,21.83l0.35,127.02l89.27,16.06l24.61-87 L374.7,21.83z M490.25,78.56l-22.26,78.7l-2.24,7.91l124.39,22.37l10.23-13.99l22.04-30.12L490.25,78.56z M623.74,144.09 l-12.29,16.8l-19.71,26.95l131.07,23.58l14.73-11.45L623.74,144.09z M739,200.67l-13.3,10.34l-0.96,0.74l58.14,10.46L739,200.67z M723.19,212.96l-25.33,19.69l-11.14,8.66l97.03-17.45L723.19,212.96z M782.89,225.5l-98.64,17.74l-107.06,83.23L782.89,225.5z M631.68,282.26l49.48-38.47l-150.1,27l-89.41,122.22l129.1-63.37L631.68,282.26z M565.06,334.05l-125.28,61.5l-45.94,62.8 l-14.96,20.44L565.06,334.05z M425.31,412.87l11.65-15.93l-42.69,20.96l-13.66,48.3l-3.58,12.67L425.31,412.87z M392.51,418.76 l-16.71,8.2l0.01,4.72l0.12,45.68L392.51,418.76z M377.21,941.96l21.37,10.36l24.14,11.7l-45.56-40.74L377.21,941.96z M377.15,921.31l34.83,31.15l12.57,11.24l-47.53-90.14L377.15,921.31z M376.63,730.07l0.38,140.33l48.29,91.59L376.63,730.07z M806.29,1197.48l75.8-58.86l-28.56,11.47l-25.6,10.28l14.96,7.25l-0.64,1.31l-16.16-7.83l-124.76,50.1l40.56,36.27L806.29,1197.48z M522.43,1146.18l58.88,111.66l52.71-21.17l64.61-25.95l-75.11-67.17L522.43,1146.18z M621.92,1142.14l-115.78-103.53l-46.8-12.07 l62.33,118.2l7.06-0.18L621.92,1142.14z M700.14,1210.12l124.19-49.87l-42.89-20.78l-155.8,4.04L700.14,1210.12z M679.7,1295.77 l61.03-47.39l-40.9-36.57l-117.85,47.32l42.09,79.82L679.7,1295.77z M522.48,1417.85l1.83-1.42l98.6-76.56l-42.28-80.19 l-84.25,33.83L522.48,1417.85z M496.08,1292.06l83.87-33.68l-59.14-112.16l-55.04,1.43L496.08,1292.06z M465.46,1146.2l54.58-1.42 l-62.61-118.74l-18.03-4.65l0.36-1.41l16.74,4.32l-27.63-52.4L465.46,1146.2z M458.42,1024.79l45.35,11.7l-74.14-66.29 L458.42,1024.79z M431.46,969.87l75.38,67.41l136.26,35.15L431.46,969.87z M649.76,1075.65l-140.54-36.25l114.83,102.68l154.53-4.01 L649.76,1075.65z M656.92,1077.5l124.84,60.5l51.97-1.35l47.7-1.24L656.92,1077.5z M784.62,1139.38l41.54,20.13l56.45-22.67 L784.62,1139.38z"/> </svg>')
+    }
+
+    // Section headers and lines
+    section > header:before, // Main line
+    section > header h1:before, section > header h1:after, // H1 connector and terminator
+    section > header h2:before, section > header h2:after { // H2 connector and terminator
+      background: map-get($dark-palette, accent-border);
+    }
+    section:last-of-type > header:after { // Terminator for the last section line
+      background: map-get($dark-palette, accent-border);
+    }
+
+    // For smaller screens where header becomes a background
+    @include breakpoint('<=medium') {
+      > section > header {
+        background-color: map-get($dark-palette, accent);
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 1750" x="0px" y="0px"> <path style="fill: #{transparentize(map-get($dark-palette, accent-border), 0.5)}" d="M889.72,1137.55l-2.91-0.75l-364.39,282.94l-0.7-0.9l-0.51,0.11l-94.77-451.5l-32.51-15.75l-16.73-8.11l0,0.68 l-1.46,0l0-1.39l-1.89-0.92l-112.41-54.47l-0.29,1.03l-1.41-0.37l0.37-1.31l-34.14-16.54l-98.56-47.76l-0.59,0.81l-1.16-0.88 l0.42-0.57L11.43,766.33l-0.25,0.2l-0.9-1.15l102.87-79.98l0.08-0.1l0.02,0.02l116.68-90.72l-0.18-0.34l1.3-0.66l0.05,0.09 l100.5-78.14l-0.07-0.32l0.65-0.14l42.3-32.89l-0.15-54.54l-0.59,0.29l-0.64-1.31l1.23-0.6l-0.01-4.54l-0.33-122.47l-0.99,0.18 l-0.28-1.43l1.27-0.23l-0.4-147.49l-0.87-0.16l0.28-1.43l0.58,0.1l-0.35-127.48l-0.13-0.06l0.64-1.31L489.97,76.8l0.73,0.19 l-0.04,0.14l132.63,65.11l0.33-0.45l1.16,0.88l-0.16,0.22l114.21,56.07l0.45-0.35l0.72,0.93l47.89,23.51l2.76-1.36l0.56,4.61 l-3.32-1.63L571.52,330.88L375.95,482.93l0.66,239.95l51.12,243.57l222.53,107.83l236.23,60.93l2.27-1.77 M375.8,425.34l17.25-8.47 l36.13-127.75l-53.73,9.66L375.8,425.34z M551,241.05l38.19-52.2l-123.83-22.27l-34.13,120.68l98.99-17.81L551,241.05z M532.3,269.09l151.34-27.22l37.63-29.25l-130.48-23.47L532.3,269.09z M303.38,733.9l-2.36-4.48l-44.18-83.78L182.5,747.25 l40.78,36.46l52.69,47.11L303.38,733.9z M277.18,831.91l56.95,50.93L375.69,920l-0.13-49.23l-71.19-135L277.18,831.91z M303.96,731.86l41.93-148.25l-9.74-46.39L257.8,644.33L303.96,731.86z M304.94,733.73l9.55,18.12l61.05,115.78l-0.39-144.6 l-16.9-80.53l-11.71-55.81L304.94,733.73z M375.21,211.79l0.23,85.51l54.17-9.74l34.29-121.23l-88.87-15.98L375.21,211.79z M430.78,288.83l-17.88,63.21L394.81,416l44.01-21.6l90.15-123.23L430.78,288.83z M287.76,898.62l87.99,42.64l-0.05-19.29 l-91.37-81.71l-7.59-6.78l-14.88,52.59L287.76,898.62z M174.26,843.62l86.26,41.8l15-53.03l-93.89-83.95l-53.34,72.91L174.26,843.62 z M113.18,687.22L12.71,765.33l55.69,26.99l58.56,28.38l53.58-73.24l-34.83-31.14L113.18,687.22z M230.62,595.92l-116.27,90.4 l63.02,56.36l4.03,3.61l74.67-102.08l-7.47-14.17L230.62,595.92z M331.94,517.15l-100.15,77.86l25.25,47.88l78.71-107.59l-1.71-8.14 L331.94,517.15z M333.22,516.15l2.02,9.64l1.66,7.92l34.65-47.37L333.22,516.15z M337.31,535.63l9.43,44.95l26.67-94.3 L337.31,535.63z M347.39,583.66l27.74,132.16l-0.62-228.04L347.39,583.66z M374.7,21.83l0.35,127.02l89.27,16.06l24.61-87 L374.7,21.83z M490.25,78.56l-22.26,78.7l-2.24,7.91l124.39,22.37l10.23-13.99l22.04-30.12L490.25,78.56z M623.74,144.09 l-12.29,16.8l-19.71,26.95l131.07,23.58l14.73-11.45L623.74,144.09z M739,200.67l-13.3,10.34l-0.96,0.74l58.14,10.46L739,200.67z M723.19,212.96l-25.33,19.69l-11.14,8.66l97.03-17.45L723.19,212.96z M782.89,225.5l-98.64,17.74l-107.06,83.23L782.89,225.5z M631.68,282.26l49.48-38.47l-150.1,27l-89.41,122.22l129.1-63.37L631.68,282.26z M565.06,334.05l-125.28,61.5l-45.94,62.8 l-14.96,20.44L565.06,334.05z M425.31,412.87l11.65-15.93l-42.69,20.96l-13.66,48.3l-3.58,12.67L425.31,412.87z M392.51,418.76 l-16.71,8.2l0.01,4.72l0.12,45.68L392.51,418.76z M377.21,941.96l21.37,10.36l24.14,11.7l-45.56-40.74L377.21,941.96z M377.15,921.31l34.83,31.15l12.57,11.24l-47.53-90.14L377.15,921.31z M376.63,730.07l0.38,140.33l48.29,91.59L376.63,730.07z M806.29,1197.48l75.8-58.86l-28.56,11.47l-25.6,10.28l14.96,7.25l-0.64,1.31l-16.16-7.83l-124.76,50.1l40.56,36.27L806.29,1197.48z M522.43,1146.18l58.88,111.66l52.71-21.17l64.61-25.95l-75.11-67.17L522.43,1146.18z M621.92,1142.14l-115.78-103.53l-46.8-12.07 l62.33,118.2l7.06-0.18L621.92,1142.14z M700.14,1210.12l124.19-49.87l-42.89-20.78l-155.8,4.04L700.14,1210.12z M679.7,1295.77 l61.03-47.39l-40.9-36.57l-117.85,47.32l42.09,79.82L679.7,1295.77z M522.48,1417.85l1.83-1.42l98.6-76.56l-42.28-80.19 l-84.25,33.83L522.48,1417.85z M496.08,1292.06l83.87-33.68l-59.14-112.16l-55.04,1.43L496.08,1292.06z M465.46,1146.2l54.58-1.42 l-62.61-118.74l-18.03-4.65l0.36-1.41l16.74,4.32l-27.63-52.4L465.46,1146.2z M458.42,1024.79l45.35,11.7l-74.14-66.29 L458.42,1024.79z M431.46,969.87l75.38,67.41l136.26,35.15L431.46,969.87z M649.76,1075.65l-140.54-36.25l114.83,102.68l154.53-4.01 L649.76,1075.65z M656.92,1077.5l124.84,60.5l51.97-1.35l47.7-1.24L656.92,1077.5z M784.62,1139.38l41.54,20.13l56.45-22.67 L784.62,1139.38z"/> </svg>');
+      }
+    }
+  }
+
+  // Intro Section specific styles
+  section.intro {
+    header {
+      h1 {
+        color: map-get($dark-palette, fg-bold); // Ensure h1 in intro is also covered
+      }
+      p {
+        color: map-get($dark-palette, fg); // General paragraph color
+        a {
+          color: map-get($dark-palette, accent); // Links within intro paragraph
+          &:hover {
+            color: map-get($dark-palette, accent-alt);
+          }
+        }
+      }
+    }
+    .content {
+      // If there's text directly in .content of intro, style it
+      color: map-get($dark-palette, fg);
+    }
+  }
+
+  // General section content
+  section {
+    header {
+      h2, h3, h4, h5, h6 { // Headers within sections
+        color: map-get($dark-palette, fg-bold);
+      }
+      p { // Paragraphs in section headers
+        color: map-get($dark-palette, fg-light);
+      }
+    }
+    .content {
+      p, strong { // Paragraphs and strong text in section content
+        color: map-get($dark-palette, fg);
+      }
+      strong {
+        color: map-get($dark-palette, fg-bold);
+      }
+      figcaption { // Image captions
+          color: map-get($dark-palette, fg-light);
+      }
+    }
+  }
+
+
+  // Buttons
+  input[type="submit"],
+  input[type="reset"],
+  input[type="button"],
+  button,
+  .button {
+    box-shadow: inset 0 0 0 2px map-get($dark-palette, border);
+    color: map-get($dark-palette, fg-bold) !important;
+
+    &:hover {
+      box-shadow: inset 0 0 0 2px map-get($dark-palette, accent-alt);
+      color: map-get($dark-palette, accent-alt) !important;
+    }
+
+    &:active {
+      background-color: map-get($dark-palette, accent-bg);
+      box-shadow: inset 0 0 0 2px map-get($dark-palette, accent-alt);
+      color: map-get($dark-palette, accent-alt) !important;
+    }
+
+    &.primary {
+      background-color: map-get($dark-palette, accent);
+      box-shadow: none;
+      color: map-get($dark-palette, fg-bold) !important; // Ensure text is readable on accent
+
+      &:hover {
+        background-color: lighten(map-get($dark-palette, accent), 5%);
+      }
+
+      &:active {
+        background-color: darken(map-get($dark-palette, accent), 5%);
+      }
+    }
+  }
+
+  // Forms
+  label {
+    color: map-get($dark-palette, fg-bold);
+  }
+
+  input[type="text"],
+  input[type="password"],
+  input[type="email"],
+  input[type="tel"],
+  input[type="search"],
+  input[type="url"],
+  select,
+  textarea {
+    border-color: map-get($dark-palette, border);
+    color: map-get($dark-palette, fg); // Text color inside input fields
+
+    &:focus {
+      border-color: map-get($dark-palette, accent-alt);
+    }
+  }
+
+  select {
+    background-image: svg-url("<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40' preserveAspectRatio='none' viewBox='0 0 40 40'><path d='M9.4,12.3l10.4,10.4l10.4-10.4c0.2-0.2,0.5-0.4,0.9-0.4c0.3,0,0.6,0.1,0.9,0.4l3.3,3.3c0.2,0.2,0.4,0.5,0.4,0.9 c0,0.4-0.1,0.6-0.4,0.9L20.7,31.9c-0.2,0.2-0.5,0.4-0.9,0.4c-0.3,0-0.6-0.1-0.9-0.4L4.3,17.3c-0.2-0.2-0.4-0.5-0.4-0.9 c0-0.4,0.1-0.6,0.4-0.9l3.3-3.3c0.2-0.2,0.5-0.4,0.9-0.4S9.1,12.1,9.4,12.3z' fill='#{map-get($dark-palette, border)}' /></svg>");
+    option {
+      background-color: map-get($dark-palette, bg);
+      color: map-get($dark-palette, fg);
+    }
+  }
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    & + label {
+      color: map-get($dark-palette, fg);
+      &:before {
+        border-color: map-get($dark-palette, border);
+      }
+    }
+
+    &:checked + label {
+      &:before {
+        background-color: map-get($dark-palette, accent);
+        border-color: map-get($dark-palette, accent);
+        color: map-get($dark-palette, bg); // Checkmark color
+      }
+    }
+
+    &:focus + label {
+      &:before {
+        border-color: map-get($dark-palette, accent);
+        box-shadow: 0 0 0 1px map-get($dark-palette, accent);
+      }
+    }
+  }
+
+  ::-webkit-input-placeholder {
+    color: map-get($dark-palette, fg-light) !important;
+  }
+  :-moz-placeholder {
+    color: map-get($dark-palette, fg-light) !important;
+  }
+  ::-moz-placeholder {
+    color: map-get($dark-palette, fg-light) !important;
+  }
+  :-ms-input-placeholder {
+    color: map-get($dark-palette, fg-light) !important;
+  }
+
+  // Lists
+  ul.alt > li {
+    border-top-color: map-get($dark-palette, border);
+  }
+
+  // Feature Icons
+  ul.feature-icons {
+    li {
+      color: map-get($dark-palette, fg); // Text color for feature icons
+      &:before {
+        // Assuming the SVG is a single color, we might need a dark-mode specific SVG or adjust fill if possible via SASS
+        // For now, let's try to make the background of the icon shape use a dark palette color
+         background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 512 512"><path d="M256,0l221.7,128v256L256,512L34.3,384V128L256,0z" fill="#{map-get($dark-palette, border-bg)}" /></svg>');
+        color: map-get($dark-palette, fg-bold); // Icon color
+      }
+    }
+  }
+
+  // Icons (social icons in footer)
+  ul.icons {
+    li {
+      .icon {
+        color: map-get($dark-palette, fg-light); // Default icon color
+        &:hover {
+          background-color: map-get($dark-palette, border-bg);
+          color: map-get($dark-palette, accent); // Icon color on hover
+        }
+      }
+    }
+  }
+  
+  // Gallery lightbox
+  .gallery {
+    .modal {
+      background-color: transparentize(map-get($dark-palette, bg), 1 - _misc(gallery-lightbox-opacity));
+      &:before { // Spinner
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="96px" height="96px" viewBox="0 0 96 96" zoomAndPan="disable"><style>circle {fill: transparent; stroke: #{map-get($dark-palette, fg-bold)}; stroke-width: 2px; }</style><defs><clipPath id="corner"><polygon points="0,0 48,0 48,48 96,48 96,96 0,96" /></clipPath></defs><g clip-path="url(#corner)"><circle cx="48" cy="48" r="32"/></g></svg>');
+      }
+      &:after { // Close button
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64px" height="64px" viewBox="0 0 64 64" zoomAndPan="disable"><style>line {stroke: #{map-get($dark-palette, fg-bold)};stroke-width: 2px;}</style><line x1="20" y1="20" x2="44" y2="44" /><line x1="20" y1="44" x2="44" y2="20" /></svg>');
+      }
+    }
+  }
+
+  // Footer
+  footer { // Assuming footer is directly under #wrapper or within a section
+    color: map-get($dark-palette, fg); // General text in footer
+    ul.items {
+      li {
+        h3 {
+          color: map-get($dark-palette, fg-bold);
+        }
+        a {
+          color: map-get($dark-palette, accent);
+          &:hover {
+            color: map-get($dark-palette, accent-alt);
+          }
+        }
+      }
+    }
+  }
+  
+  // Copyright
+  .copyright {
+    color: map-get($dark-palette, fg-light);
+    a {
+      color: inherit; // Should inherit fg-light
+      &:hover {
+        color: map-get($dark-palette, accent);
+      }
+    }
+  }
+}

--- a/assets/sass/libs/_vars.scss
+++ b/assets/sass/libs/_vars.scss
@@ -51,3 +51,17 @@
 		accent-alt:				desaturate(darken(#49fcd4, 10), 20),
 		accent-bg:				transparentize(#49fcd4, 0.75)
 	);
+
+// Dark Mode Palette.
+	$dark-palette: (
+		bg:						#121212, // Dark gray background
+		fg:						#e0e0e0, // Light gray text
+		fg-bold:				#ffffff, // White bold text
+		fg-light:				rgba(224,224,224,0.25), // Lighter gray for secondary text
+		border:					rgba(224,224,224,0.25), // Light gray border
+		border-bg:				rgba(224,224,224,0.1), // Lighter gray border background
+		accent:					#7f5af0, // Purple accent
+		accent-border:			desaturate(darken(#7f5af0, 8), 30),
+		accent-alt:				desaturate(darken(#7f5af0, 10), 20),
+		accent-bg:				transparentize(#7f5af0, 0.75)
+	);

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -50,3 +50,6 @@
 // Layout.
 
 	@import 'layout/wrapper';
+
+// Dark Theme.
+	@import 'base/dark-theme';

--- a/index.html
+++ b/index.html
@@ -323,6 +323,10 @@
 							<!-- <li><a href="#" class="icon brands fa-codepen"><span class="label">Codepen</span></a></li> -->
 						</ul>
 					</li>
+					<li>
+						<h3>Mode d'affichage</h3>
+						<button id="darkModeToggle" class="button">Changer de mode</button>
+					</li>
 				</ul>
 				<div id="gif"><img data-src="images/giphy.gif" alt="GIF rigolo de chat cassant un ordinateur"
 						class="lazy"></div>


### PR DESCRIPTION
Adds a dark mode feature to the website.

Key changes include:
- Defined a new color palette for dark mode in `assets/sass/libs/_vars.scss`.
- Created `assets/sass/base/_dark-theme.scss` to house the dark mode styles, using the new color variables. This is imported into `main.scss`.
- Added a toggle button in the footer of `index.html` to switch between light and dark modes.
- Implemented JavaScript functionality in `assets/js/main.js` to handle:
    - Toggling a `dark-mode` class on the body.
    - Saving your theme preference to `localStorage`.
    - Loading the saved preference on page load.
    - Updating the button text based on the current mode.

I've outlined manual testing steps, and the code has been reviewed for expected behavior. I recommend direct browser testing by you to confirm visual and interactive correctness.